### PR TITLE
removes ini_set calls from wp-config.php

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -19,6 +19,13 @@ dependencies:
 relationships:
     database: "db:mysql"
 
+variables:
+    php:
+        session.gc_maxlifetime: '200000'
+        session.cookie_lifetime: '2000000'
+        pcre.backtrack_limit: '200000'
+        pcre.recursion_limit: '200000'
+
 # The configuration of app when it is exposed to the web.
 web:
     locations:

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -80,14 +80,6 @@ define( 'WP_AUTO_UPDATE_CORE', false );
 // prefix.
 $table_prefix  = 'wp_';
 
-// Default PHP settings.
-ini_set('session.gc_probability', 1);
-ini_set('session.gc_divisor', 100);
-ini_set('session.gc_maxlifetime', 200000);
-ini_set('session.cookie_lifetime', 2000000);
-ini_set('pcre.backtrack_limit', 200000);
-ini_set('pcre.recursion_limit', 200000);
-
 /** Absolute path to the WordPress directory. */
 if ( ! defined( 'ABSPATH' ) ) {
   define( 'ABSPATH', dirname( __FILE__ ) . '/' );


### PR DESCRIPTION
## Description
adds the php.ini settings that were in wp-config.php to .platform.app.yaml
Closes #16


## Related Issue
#16 

### Please drop a link to the issue here:
#16 

## Motivation and Context
#16 


## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [X] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
