### PR TITLE
Update sourceops.yaml

### DIFF
--- a/.github/workflows/sourceops.yaml
+++ b/.github/workflows/sourceops.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: "Make sure it is sync'ed"
         id: 'sync-update-branch'
         run: |
-          git pull origin main
+          git pull origin ${{ github.event.repository.default_branch }}
           git push -u origin ${UPDATE_BRANCH}
 
 


### PR DESCRIPTION
not all branches are main.
uses the variables we have access to
was hard-coded to main when syncing update branch

## Description
Please describe your changes in detail according to the information below

## Related Issue
This project only accepts pull requests related to open issues.
- If suggesting a new feature or change, please discuss it in an issue first
- If fixing a bug, there should be an issue describing it with steps to reproduce it following the bug report guide
- If you're suggesting a feature, please follow the feature request guide by clicking on issues

### Please drop a link to the issue here:

## Motivation and Context
Why is this change required? What problem does it solve?

## How Has This Been Tested?
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [ ] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
